### PR TITLE
Add CRUD functionality to Service

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "react": "webpack -d --watch",
     "server": "nodemon server/index.js rs",
-    "start": "node server/index.js rs",
+    "start": "nodemon server/index.js",
     "seed": "knex seed:run",
     "test": "jest"
   },

--- a/server/CRUD.md
+++ b/server/CRUD.md
@@ -1,0 +1,81 @@
+## GET '/espn/teamstandings'
+
+---
+
+- Request received when status code ``200`` is given
+- Will grab the last 100 records from the DBMS
+- Renders all 100 records to the DOM
+
+```
+app.get('/espn/teamstandings', (req, res) => {
+  Standings.reset()
+    .orderBy('id', 'DESC')
+    .query((qb) => {
+      qb.limit(100);
+    })
+    .fetch()
+    .then((data) => {
+      res.status(200).send(data.models);
+    });
+});
+```
+
+---
+
+## POST '/espn/teamstandings'
+
+---
+
+- Request status code ``201`` is given
+- Will add a dummy record to the database and render it to the DOM
+
+```
+app.post('/espn/teamstandings', (req, res) => {
+  db.knex('standings').insert({
+    team_name: 'The Flying Dutchmen',
+    division: 'NFC WEST',
+    wins: 9000,
+    losses: 0,
+    tie: 0,
+    percentage: 1.00,
+    points_for: 100,
+    points_against: 0,
+    team_logo: 'https://a.espncdn.com/combiner/i?img=/i/teamlogos/nfl/500/scoreboard/sea.png&h=40&w=40',
+    link: 'https://www.youtube.com/watch?v=WpE_xMRiCLE&t=0s&list=FLI_MZWTHPVBrsOofhX5Ceug&index=86'
+  }).then(() => res.status(201).send('Successfully inserted team'));
+});
+```
+
+---
+
+## PUT '/espn/teamstandings'
+
+---
+
+- Updates the dummy record inserted by the ``POST`` route
+- Request status code ``303`` is given
+
+```
+app.put('/espn/teamstandings', (req, res) => {
+  db.knex('standings')
+    .where({team_name: 'The Flying Dutchmen'})
+    .update({team_name: 'Mars Rovers'})
+    .then(() => res.status(303).send('Updated team'));
+});
+```
+
+---
+
+## DELETE '/espn/teamstandings'
+
+- Deletes the dummy record inserted by the ``POST`` route
+- Request status code ``303`` is given
+
+```
+app.delete('/espn/teamstandings', (req, res) => {
+  db.knex('standings')
+    .where({link: 'https://www.youtube.com/watch?v=WpE_xMRiCLE&t=0s&list=FLI_MZWTHPVBrsOofhX5Ceug&index=86'})
+    .del()
+    .then(() => res.status(303).send('1 team deleted'));
+});
+```

--- a/server/CRUD.md
+++ b/server/CRUD.md
@@ -1,7 +1,5 @@
 ## GET '/espn/teamstandings'
 
----
-
 - Request received when status code ``200`` is given
 - Will grab the last 100 records from the DBMS
 - Renders all 100 records to the DOM
@@ -23,8 +21,6 @@ app.get('/espn/teamstandings', (req, res) => {
 ---
 
 ## POST '/espn/teamstandings'
-
----
 
 - Request status code ``201`` is given
 - Will add a dummy record to the database and render it to the DOM
@@ -49,8 +45,6 @@ app.post('/espn/teamstandings', (req, res) => {
 ---
 
 ## PUT '/espn/teamstandings'
-
----
 
 - Updates the dummy record inserted by the ``POST`` route
 - Request status code ``303`` is given
@@ -79,3 +73,5 @@ app.delete('/espn/teamstandings', (req, res) => {
     .then(() => res.status(303).send('1 team deleted'));
 });
 ```
+
+---

--- a/server/app.js
+++ b/server/app.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const Standings = require('../database/collections/standings.js');
-
+const db = require('../database/config.js');
 const app = express();
 
 app.use(cors());
@@ -21,16 +21,33 @@ app.get('/espn/teamstandings', (req, res) => {
     });
 });
 
-app.post('/add-team', (req, res) => {
-
+app.post('/espn/teamstandings', (req, res) => {
+  db.knex('standings').insert({
+    team_name: 'The Flying Dutchmen',
+    division: 'NFC WEST',
+    wins: 9000,
+    losses: 0,
+    tie: 0,
+    percentage: 1.00,
+    points_for: 100,
+    points_against: 0,
+    team_logo: 'https://a.espncdn.com/combiner/i?img=/i/teamlogos/nfl/500/scoreboard/sea.png&h=40&w=40',
+    link: 'https://www.youtube.com/watch?v=WpE_xMRiCLE&t=0s&list=FLI_MZWTHPVBrsOofhX5Ceug&index=86'
+  }).then(() => res.status(201).send('Successfully inserted team'));
 });
 
-app.put('/update-team', (req, res) => {
-
+app.put('/espn/teamstandings', (req, res) => {
+  db.knex('standings')
+    .where({team_name: 'The Flying Dutchmen'})
+    .update({team_name: 'Mars Rovers'})
+    .then(() => res.status(303).send('Updated team'));
 });
 
-app.delete('/delete-team', (req, res) => {
-
+app.delete('/espn/teamstandings', (req, res) => {
+  db.knex('standings')
+    .where({link: 'https://www.youtube.com/watch?v=WpE_xMRiCLE&t=0s&list=FLI_MZWTHPVBrsOofhX5Ceug&index=86'})
+    .del()
+    .then(() => res.status(303).send('1 team deleted'));
 });
 
 module.exports = app;

--- a/server/app.js
+++ b/server/app.js
@@ -21,4 +21,16 @@ app.get('/espn/teamstandings', (req, res) => {
     });
 });
 
+app.post('/add-team', (req, res) => {
+
+});
+
+app.put('/update-team', (req, res) => {
+
+});
+
+app.delete('/delete-team', (req, res) => {
+
+});
+
 module.exports = app;


### PR DESCRIPTION
### **Context**

Support for basic CRUD (Create, Read, Update, Delete) operations has now been added to the standings service for the primary database (Postgres). 

**What's included with this PR**
---

**1).**

- Added a ``POST`` route that inserts a dummy record to the DBMS. This will also render the dummy record to the DOM. 

**2).**

- Added a ``PUT`` route that will update the dummy record's team name from the ``POST`` route. 

**3).**

- Added a ``DELETE`` route to remove the dummy record from the ``POST`` route.

**4).**

- Modified the script that starts the server for automatic refreshing.
